### PR TITLE
filters: use proper height for setting viewport

### DIFF
--- a/src/filters.cpp
+++ b/src/filters.cpp
@@ -24,7 +24,6 @@
 
 #include <string>
 #include <fstream>
-#include <streambuf>
 #include <wayfire/core.hpp>
 #include <wayfire/view.hpp>
 #include <wayfire/plugin.hpp>
@@ -170,7 +169,7 @@ class wf_filters : public wf::scene::view_2d_transformer_t
 
             /* Render it to target */
             target.bind();
-            GL_CALL(glViewport(x, fb_geom.height - y - h, w, h));
+            GL_CALL(glViewport(x, target.viewport_height - y - h, w, h));
 
             GL_CALL(glEnable(GL_BLEND));
             GL_CALL(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));


### PR DESCRIPTION
The reason this is needed is that for example Expo uses subbuffers of a render target, which is basically a way of specifying that only a part of the framebuffer should be used. So when subbuffers are used, fb_geom will actually not be equal to the actual size of the framebuffer, but only to the part of it where we render. To set glViewport however one needs to take into account the full framebuffer size which is available in viewport_height.